### PR TITLE
Immediately submit on SIGUSR1

### DIFF
--- a/src/mpdscribble.c
+++ b/src/mpdscribble.c
@@ -50,6 +50,11 @@ static gboolean exit_signal_handler(G_GNUC_UNUSED gpointer user_data) {
 	return true;
 }
 
+static gboolean submit_signal_handler(G_GNUC_UNUSED gpointer user_data) {
+  as_submit_now();
+	return true;
+}
+
 static void setup_signals(void)
 {
 	signal(SIGPIPE, SIG_IGN);
@@ -57,6 +62,8 @@ static void setup_signals(void)
 	g_unix_signal_add(SIGINT, exit_signal_handler, NULL);
 	g_unix_signal_add(SIGTERM, exit_signal_handler, NULL);
 	g_unix_signal_add(SIGHUP, exit_signal_handler, NULL);
+
+	g_unix_signal_add(SIGUSR1, submit_signal_handler, NULL);
 }
 #endif
 

--- a/src/scrobbler.c
+++ b/src/scrobbler.c
@@ -889,6 +889,31 @@ void as_save_cache(void)
 }
 
 static void
+scrobbler_submit_now_callback(gpointer data, G_GNUC_UNUSED gpointer user_data)
+{
+	struct scrobbler *scrobbler = data;
+
+	scrobbler->interval = 1;
+
+	if (scrobbler->handshake_source_id != 0) {
+		g_source_remove(scrobbler->handshake_source_id);
+		scrobbler->handshake_source_id = 0;
+		scrobbler_schedule_handshake(scrobbler);
+	}
+
+	if (scrobbler->submit_source_id != 0) {
+		g_source_remove(scrobbler->submit_source_id);
+		scrobbler->submit_source_id = 0;
+		scrobbler_schedule_submit(scrobbler);
+	}
+}
+
+void as_submit_now(void)
+{
+	g_slist_foreach(scrobblers, scrobbler_submit_now_callback, NULL);
+}
+
+static void
 scrobbler_free_callback(gpointer data, G_GNUC_UNUSED gpointer user_data)
 {
 	struct scrobbler *scrobbler = data;

--- a/src/scrobbler.h
+++ b/src/scrobbler.h
@@ -66,7 +66,7 @@ as_songchange(const char *file, const char *artist, const char *track,
 	      const char *time);
 
 void as_save_cache(void);
-
+void as_submit_now(void);
 char *as_timestamp(void);
 
 #endif /* SCROBBLER_H */


### PR DESCRIPTION
It's not unusual to travel without Internet. After going online afterwards, I have to wait for *2 hours* until mpdscribble begins to synchronize again. In this situation, I have to kill mpdscribble and restart it manually.

The pull request upgrades the signal handling mechanism to GLib to cope with the scary signal handler. On SIGUSR1, it reschedules all timers with the interval of 1 second.