### PR TITLE
IniFile: allow underscores in key names

### DIFF
--- a/src/IniFile.cxx
+++ b/src/IniFile.cxx
@@ -50,7 +50,7 @@ IsValidSectionName(StringView name) noexcept
 static constexpr bool
 IsValidKeyChar(char ch) noexcept
 {
-	return IsAlphaNumericASCII(ch);
+	return IsAlphaNumericASCII(ch) || ch == '_';
 }
 
 gcc_pure


### PR DESCRIPTION
Was running into an "invalid key" error when having the "daemon_user" key set in the configuration file, the issue being that it contains and underscore. This key and others are still defined in ReadConfig.cxx so I assume they are not deprecated options.