### PR TITLE
Follow XDG Base Dir Spec

### DIFF
--- a/doc/mpdscribble.1
+++ b/doc/mpdscribble.1
@@ -70,8 +70,8 @@ HTTP proxy URL.
 Specify how verbosely mpdscribble should log.  Possible values are 0
 to 3, defaulting to 1.
 .SH CONFIGURATION
-mpdscribble looks for its configuration file first at 
-~/.mpdscribble/mpdscribble.conf and then at /etc/mpdscribble.conf
+mpdscribble looks for its configuration file in the following order:
+$XDG_CONFIG_HOME/mpdscribble/mpdscribble.conf, ~/.config/mpdscribble/mpdscribble.conf, ~/.mpdscribble/mpdscribble.conf, /etc/mpdscribble.conf
 (if \-\-sysconfdir=/etc)
 but this can be overridden by specifying an alternate configuration
 file using the command line option
@@ -132,7 +132,7 @@ have a connection to the scrobbler.  This option used to be called
 The system wide configuration file. 
 .RE
 
-.I ~/.mpdscribble/mpdscribble.conf
+.I ~/.config/mpdscribble/mpdscribble.conf
 .RS
 Per user configuration file. 
 .RE
@@ -142,7 +142,7 @@ Per user configuration file.
 The system wide Last.fm cache file.
 .RE
 
-.I ~/.mpdscribble/mpdscribble.cache
+.I ~/.cache/mpdscribble/mpdscribble.cache
 .RS
 Per user Last.fm cache file.
 .RE
@@ -152,9 +152,6 @@ Per user Last.fm cache file.
 The system wide log file. 
 .RE
 
-.I ~/.mpdscribble/mpdscribble.log
-.RS
-Per user log file. 
 .RE
 .SH BUGS
 File permissions on cache/log file may be insecure by default.

--- a/src/ReadConfig.cxx
+++ b/src/ReadConfig.cxx
@@ -47,8 +47,6 @@
 #ifndef _WIN32
 
 #define FILE_CACHE "/var/cache/mpdscribble/mpdscribble.cache"
-#define FILE_HOME_CONF "~/.mpdscribble/mpdscribble.conf"
-#define FILE_HOME_CACHE "~/.mpdscribble/mpdscribble.cache"
 
 #endif
 
@@ -81,7 +79,18 @@ static std::string
 get_default_config_path(Config &config)
 {
 #ifndef _WIN32
-	auto file = file_expand_tilde(FILE_HOME_CONF);
+	const char *XDG_CONFIG_HOME = getenv("XDG_CONFIG_HOME");
+	std::string FILE_HOME_CONF;
+	std::string LEGACY_FILE_HOME_CONF = "~/.mpdscribble/mpdscribble.conf";
+	if (XDG_CONFIG_HOME) {
+		FILE_HOME_CONF =
+			std::string(XDG_CONFIG_HOME) + "/mpdscribble/mpdscribble.conf";
+	} else if (file_exists(LEGACY_FILE_HOME_CONF.c_str())) {
+		FILE_HOME_CONF = LEGACY_FILE_HOME_CONF;
+	} else {
+		FILE_HOME_CONF = "~/.config/mpdscribble/mpdscribble.conf";
+	}
+	auto file = file_expand_tilde(FILE_HOME_CONF.c_str());
 	if (file_exists(file.c_str())) {
 		config.loc = file_home;
 		return file;
@@ -114,9 +123,21 @@ static std::string
 get_default_cache_path(const Config &config)
 {
 #ifndef _WIN32
+	const char *XDG_CACHE_HOME = getenv("XDG_CACHE_HOME");
+	std::string FILE_HOME_CACHE;
+		std::string LEGACY_FILE_HOME_CACHE = "~/.mpdscribble/mpdscribble.cache";
+	if (XDG_CACHE_HOME) {
+		FILE_HOME_CACHE =
+			std::string(XDG_CACHE_HOME) + "/mpdscribble/mpdscribble.cache";
+	} else if (file_exists(LEGACY_FILE_HOME_CACHE.c_str())) {
+		FILE_HOME_CACHE = LEGACY_FILE_HOME_CACHE;
+		} else {
+	  FILE_HOME_CACHE = "~/.config/mpdscribble/mpdscribble.cache";
+	}
+
 	switch (config.loc) {
 	case file_home:
-		return file_expand_tilde(FILE_HOME_CACHE);
+		return file_expand_tilde(FILE_HOME_CACHE.c_str());
 
 	case file_etc:
 		return FILE_CACHE;


### PR DESCRIPTION
I have 0 hours of C++ experience so this is probably bad. I also didn't add legacy support to fallback to `~/.mpdscribble/` but that may be desirable. Would fix #15 and match MPD's behavior.