### PR TITLE
systemd: fix user unit WantedBy

### DIFF
--- a/systemd/user/mpdscribble.service.in
+++ b/systemd/user/mpdscribble.service.in
@@ -30,4 +30,4 @@ RestrictNamespaces=yes
 # permitted")
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
multi-user.target doesn't exist in systemd user mode, default.target is the equivalent there