### PR TITLE
Scrobbler: Reduce maximum backoff interval to 480 seconds

### DIFF
--- a/src/Scrobbler.cxx
+++ b/src/Scrobbler.cxx
@@ -39,6 +39,9 @@
 /* don't submit more than this amount of songs in a batch. */
 #define MAX_SUBMIT_COUNT 10
 
+/* maximum exponential backoff delay */
+#define MAX_INTERVAL (60 << 3)
+
 namespace ResponseStrings {
 static constexpr char OK[] = "OK";
 static constexpr char BADSESSION[] = "BADSESSION";
@@ -88,8 +91,8 @@ Scrobbler::IncreaseInterval() noexcept
 	else
 		interval <<= 1;
 
-	if (interval > 60 * 60 * 2)
-		interval = 60 * 60 * 2;
+	if (interval > MAX_INTERVAL)
+		interval = MAX_INTERVAL;
 
 	FormatWarning("[%s] waiting %u seconds before trying again",
 		      config.name.c_str(), interval);


### PR DESCRIPTION
Since mpdscribble is often a long running process, it typically stays
running even when the system running it is not connected to the
internet. For example, if one brings a laptop on a plane.

In my case, I frequently bring my laptop on planes or trains where
internet connectivity is either nonexistent or extremely limited. When I
then return to a place where connectivity is restored and play music, it
usually takes two hours -- the maximum allowed interval -- before any
scrobbles are submitted, as the maximum interval has already been
accrued in that time.

This is especially prevalent because the interval is handled by
scheduling based on the monotonic forward progress of the system, and so
(for example) doesn't advance time when the system is suspended. This
means that the interval may in reality be far longer.

Reducing the maximum interval to 480 seconds improves this case: it
makes sure we back off acceptably during periods where we cannot contact
the API, without running up into intervals that span multiple hours.