### PR TITLE
Fix build with GCC 12 (missing <time.h> include)

### DIFF
--- a/src/Log.cxx
+++ b/src/Log.cxx
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #ifdef HAVE_SYSLOG
 #include <syslog.h>


### PR DESCRIPTION
Fixes the following build failure with GCC 12:
```
FAILED: mpdscribble.p/src_Log.cxx.o
[...]
../mpdscribble-0.24/src/Log.cxx: In function ‘const char* log_date()’:
../mpdscribble-0.24/src/Log.cxx:48:13: error: ‘time’ was not declared in this scope
   48 |         t = time(nullptr);
      |             ^~~~
../mpdscribble-0.24/src/Log.cxx:49:15: error: ‘localtime’ was not declared in this scope
   49 |         tmp = localtime(&t);
      |               ^~~~~~~~~
../mpdscribble-0.24/src/Log.cxx:55:14: error: ‘strftime’ was not declared in this scope
   55 |         if (!strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S%z", tmp)) {
      |              ^~~~~~~~
```

Bug: https://bugs.gentoo.org/851513