### PR TITLE
Fix out-of-bounds read bug in Scrobbler.cxx:as_md5 due to missing null-termination

### DIFF
--- a/src/Scrobbler.cxx
+++ b/src/Scrobbler.cxx
@@ -344,14 +344,18 @@ as_md5(const std::string &password, const std::string &timestamp)
 {
 	std::array<char, MD5_HEX_SIZE> buffer;
 
-	auto password_md5 = std::string(password);
+	auto password_md5 = std::string_view(password);
 	if (password.length() != 32) {
 		/* assume it's not hashed yet */
 		buffer = md5_hex(password);
-		password_md5 = std::string(buffer.data(), MD5_HEX_SIZE);
+		password_md5 = std::string_view(buffer.data(), MD5_HEX_SIZE);
 	}
 
-	return md5_hex(password_md5 + timestamp);
+	std::string md5_with_timestamp;
+	md5_with_timestamp.reserve(password_md5.size() + timestamp.size());
+	md5_with_timestamp.append(password_md5);
+	md5_with_timestamp.append(timestamp);
+	return md5_hex(md5_with_timestamp);
 }
 
 void

--- a/src/Scrobbler.cxx
+++ b/src/Scrobbler.cxx
@@ -344,11 +344,11 @@ as_md5(const std::string &password, const std::string &timestamp)
 {
 	std::array<char, MD5_HEX_SIZE> buffer;
 
-	const char *password_md5 = password.c_str();
+	auto password_md5 = std::string(password);
 	if (password.length() != 32) {
 		/* assume it's not hashed yet */
 		buffer = md5_hex(password);
-		password_md5 = buffer.data();
+		password_md5 = std::string(buffer.data(), MD5_HEX_SIZE);
 	}
 
 	return md5_hex(password_md5 + timestamp);


### PR DESCRIPTION
`buffer` is not null terminated, but is implicitly interpreted as a C-string in the call to `md5_hex`. The fix is to convert it to a std::string beforehand, with its length (MD5_HEX_SIZE) given explicitly.

Fixes #47