### PR TITLE
systemd: use PrivateUsers= in user unit

### DIFF
--- a/systemd/user/mpdscribble.service.in
+++ b/systemd/user/mpdscribble.service.in
@@ -13,6 +13,8 @@ MemorySwapMax=64M
 TasksMax=4
 DevicePolicy=closed
 
+# Required in order for ProtectSystem= (and other sandboxing) to work
+PrivateUsers=yes
 # disallow writing to /usr, /bin, /sbin, ...
 ProtectSystem=yes
 


### PR DESCRIPTION
ProtectSystem= and other sandboxing options require a user namespace in order to work as user units (the user manager does not run as root and thus without a user namespace it is unable to perform mounts).

We are looking to enable this implicitly. Very few user units use these options, so want to make sure it is intentional and won't cause regressions. The alternative is to remove ProtectSystem=.