### PR TITLE
Fixing Windows Support

### DIFF
--- a/src/event/SocketEvent.hxx
+++ b/src/event/SocketEvent.hxx
@@ -60,7 +60,9 @@ public:
 	 */
 	static constexpr unsigned IMPLICIT_FLAGS = ERROR|HANGUP;
 
+	#ifndef _WIN32
 	using ssize_t = std::make_signed<size_t>::type;
+	#endif
 
 	SocketEvent(EventLoop &_loop, Callback _callback,
 		    SocketDescriptor _fd=SocketDescriptor::Undefined()) noexcept

--- a/src/io/FileDescriptor.cxx
+++ b/src/io/FileDescriptor.cxx
@@ -28,6 +28,15 @@
 #define O_CLOEXEC 0
 #endif
 
+#ifdef _WIN32
+typedef int mode_t;
+	#if defined(_WIN64)
+	 typedef __int64 ssize_t; 
+	#else
+	 typedef long ssize_t;
+	#endif
+#endif
+
 #ifndef _WIN32
 
 bool

--- a/src/io/FileDescriptor.hxx
+++ b/src/io/FileDescriptor.hxx
@@ -188,16 +188,28 @@ public:
 	bool Rewind() noexcept;
 
 	off_t Seek(off_t offset) noexcept {
+		#ifdef _WIN32
+		return _lseek(Get(), offset, SEEK_SET);
+		#else
 		return lseek(Get(), offset, SEEK_SET);
+		#endif
 	}
 
 	off_t Skip(off_t offset) noexcept {
+		#ifdef _WIN32
+		return _lseek(Get(), offset, SEEK_CUR);
+		#else
 		return lseek(Get(), offset, SEEK_CUR);
+		#endif
 	}
 
 	[[gnu::pure]]
 	off_t Tell() const noexcept {
+		#ifdef _WIN32
+		return _lseek(Get(), 0, SEEK_CUR);
+		#else
 		return lseek(Get(), 0, SEEK_CUR);
+		#endif
 	}
 
 	/**

--- a/src/io/FileDescriptor.hxx
+++ b/src/io/FileDescriptor.hxx
@@ -12,7 +12,14 @@
 #include <sys/types.h>
 
 #ifdef _WIN32
+#include <io.h>
 #include <wchar.h>
+typedef int mode_t;
+#if defined(_WIN64)
+ typedef __int64 ssize_t; 
+#else
+ typedef long ssize_t;
+#endif
 #endif
 
 class UniqueFileDescriptor;

--- a/src/io/FileDescriptor.hxx
+++ b/src/io/FileDescriptor.hxx
@@ -6,7 +6,9 @@
 #include <cstddef>
 #include <utility>
 
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <sys/types.h>
 
 #ifdef _WIN32

--- a/src/lib/wincrypt/meson.build
+++ b/src/lib/wincrypt/meson.build
@@ -4,6 +4,9 @@ wincrypt = static_library(
   include_directories: inc,
 )
 
+cryptlib_dep = compiler.find_library('crypt32')
+
 wincrypt_dep = declare_dependency(
   link_with: wincrypt,
+  dependencies: cryptlib_dep
 )

--- a/src/net/SocketDescriptor.hxx
+++ b/src/net/SocketDescriptor.hxx
@@ -15,6 +15,11 @@
 
 #ifdef _WIN32
 #include <winsock2.h> // for SOCKET, INVALID_SOCKET
+	#if defined(_WIN64)
+	 typedef __int64 ssize_t; 
+	#else
+	 typedef long ssize_t;
+	#endif
 #endif
 
 class SocketAddress;

--- a/src/system/Error.hxx
+++ b/src/system/Error.hxx
@@ -20,9 +20,7 @@ FormatSystemError(std::error_code code, const char *fmt,
 
 #ifdef _WIN32
 
-#include <errhandlingapi.h> // for GetLastError()
-#include <windef.h> // for HWND (needed by winbase.h)
-#include <winbase.h> // for FormatMessageA()
+#include <Windows.h>
 
 /**
  * Returns the error_category to be used to wrap WIN32 GetLastError()

--- a/src/system/meson.build
+++ b/src/system/meson.build
@@ -1,6 +1,6 @@
 system_sources = []
 
-if host_machine.system() != 'windows'
+if host_machine.system() == 'windows'
   system_sources += [
     'EventPipe.cxx',
   ]


### PR DESCRIPTION
Compiling on Windows seems to be completely impossible at the moment. This PR includes some of my fixes to attempt to get it in a working state again.

- [x] Remove libgcc reliance
- [x] Function Caller Typos
- [ ] Incomplete Type Classes
	- [ ] IPv4Address
	- [ ] SocketAddress
- [ ] Log template syntax errors

I've already removed most of the libgcc reliance, and all the function caller typos. The two areas that I really need help with and can't do on my own are the Incomplete Type Classes and the fact that `Log.hxx` has syntax errors because of the invalid template syntax.

In the future, I'd also like to contribute to getting some sort of CI working with AppVeyor or similar. That way this situation becomes impossible, or at least harder to get into.