### PR TITLE
Build Windows Executable from GitHub Actions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install build tools
-        run: choco install meson --version 1.0.1 -y
+        run: choco install meson --version 1.0.1 -y --usepackagecodes
       - name: Setup build environment
         run: meson build
       - name: Compile project

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install build tools
-        run: choco install meson --version 1.0.1 -y --ignorepackagecodes && refreshenv
+        run: choco install meson --version 1.0.1 -y --ignorepackagecodes && choco install ninja --version 1.11.1 -y --ignorepackagecodes && refreshenv
       - name: Setup build environment
-        run: meson build
+        run: &'C:\Program Files\Meson\meson.exe' build
       - name: Compile project
         run: cd .\build\ && ninja -j4
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install build tools
-        run: choco install meson --version 1.0.1 -y --ignorepackagecodes
+        run: choco install meson --version 1.0.1 -y --ignorepackagecodes && refreshenv
       - name: Setup build environment
         run: meson build
       - name: Compile project

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,11 +13,17 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install build tools
-        run: choco install meson --version 1.0.1 -y --ignorepackagecodes && choco install ninja --version 1.11.1 -y --ignorepackagecodes && refreshenv
+        run: >
+            choco install meson --version 1.0.1 -y --ignorepackagecodes;
+            choco install ninja --version 1.11.1 -y --ignorepackagecodes;
+            refreshenv
       - name: Setup build environment
-        run: &'C:\Program Files\Meson\meson.exe' build
+        run: >
+            &'C:\Program Files\Meson\meson.exe' build;
       - name: Compile project
-        run: cd .\build\ && ninja -j4
+        run: >
+            cd .\build\;
+            ninja -j4;
       - uses: actions/upload-artifact@v3
         with:
           name: mpdscribble-windows-amd64.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install build tools
-        run: choco install meson --version 1.0.1 -y --usepackagecodes
+        run: choco install meson --version 1.0.1 -y --ignorepackagecodes
       - name: Setup build environment
         run: meson build
       - name: Compile project

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -7,6 +7,9 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    env:
+        CC: clang
+        CXX: clang++
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,24 @@
+name: Windows CI
+on: [push, pull_request]
+
+jobs:
+  win10-clang:
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install build tools
+        run: choco install meson --version 1.0.1 -y
+      - name: Setup build environment
+        run: meson build
+      - name: Compile project
+        run: cd .\build\ && ninja -j4
+      - uses: actions/upload-artifact@v3
+        with:
+          name: mpdscribble-windows-amd64.exe
+          path: mpdscribble.exe


### PR DESCRIPTION
While trying to get Windows support working again, I figure having feedback on where builds fail can help us determine next steps and changes to fix issues. Currently, the workflow is usable, but fails soon after running as it requires the curl kludge to continue compiling.