### PR TITLE
Add feature:  Ignore lists

### DIFF
--- a/doc/mpdscribble.1
+++ b/doc/mpdscribble.1
@@ -126,6 +126,56 @@ Your Last.fm password, either cleartext or its MD5 sum.
 The file where mpdscribble should store its journal in case you do not
 have a connection to the scrobbler.  This option used to be called
 "cache".  It is optional.
+.TP
+.B ignore = FILE
+Include an ignore file for this scrobbler to exclude tracks from scrobbling.
+
+.SH IGNORE FILE FORMAT
+Tracks can be ignored by listing them in an \fBignore file\fP.
+Each line in the file specifies a pattern to match tracks you wish to exclude from scrobbling.
+The format is simple and flexible, allowing you to match by artist, album, title, track number or a combination of these fields.
+.SS File Format
+A tag match is specified as tagname="value", where tagname is replaced with one of the supported tags (artist, album, title, track).
+Values \fBmust\fP be quoted and spaces are not allowed surrounding the equal sign.
+
+Each line consists of one or more tag matches separated by spaces:
+.nf
+.in +4
+tag1="value1" tag2="value2" ...
+.in
+.fi
+
+Tags can appear in any order and blank lines are ignored.
+
+A backslash (\e) is interpreted as escape character and may be used to escape literal double quotes within a value.
+To write a literal backslash, use a double backslash (\e\e).
+
+Each line is limited to 4096 characters including the newline character.
+Superflous characters are silently ignored.
+
+.SS Examples
+If a tag is omitted, any value for that field is matched:
+.TP
+.B title="Bohemian Rhapsody"
+Matches any track titled \fIBohemian Rhapsody\fP.
+.TP
+.B artist="Queen"
+Matches any track by \fIQueen\fP, regardless of album or title.
+.TP
+.B artist="Queen" album="A Night at the Opera"
+Matches any track by \fIQueen\fP from \fIA Night at the Opera\fP, regardless of title.
+.TP
+.B artist="Queen" album="A Night at the Opera" title="Bohemian Rhapsody"
+Matches a specific track by \fIQueen\fP, from \fIA Night at the Opera\fP, titled \fIBohemian Rhapsody\fP.
+.TP
+.B artist="Queen" album="A Night at the Opera" track="01"
+Matches the first track on the album \fIA Night at the Opera\fP by \fIQueen\fP.
+Note that track tags are interpreted as text and not numbers, meaning "01" is not the same as "1".
+.TP
+.B artist="Clark \e"Plazmataz\e" Powell"
+Matches tracks by \fIClark "Plazmataz" Powell\fP.
+
+
 .SH FILES
 .I /etc/mpdscribble.conf
 .RS

--- a/doc/mpdscribble.conf
+++ b/doc/mpdscribble.conf
@@ -37,6 +37,8 @@ password =
 # The file where mpdscribble should store its Last.fm journal in case
 # you do not have a connection to the Last.fm server.
 journal = /var/cache/mpdscribble/lastfm.journal
+# Optional ignore file, see manpage for details!
+#ignore = /etc/mpdscribble_lastfm.ignore
 
 #[libre.fm]
 #url = http://turtle.libre.fm/

--- a/meson.build
+++ b/meson.build
@@ -208,6 +208,7 @@ executable(
   'src/MpdObserver.cxx',
   'src/Log.cxx',
   'src/XdgBaseDirectory.cxx',
+  'src/IgnoreList.cxx',
 
   include_directories: inc,
   dependencies: [

--- a/src/Config.hxx
+++ b/src/Config.hxx
@@ -8,6 +8,7 @@
 
 #include <forward_list>
 #include <string>
+#include <map>
 
 enum file_location { file_etc, file_home, file_unknown, };
 
@@ -17,7 +18,10 @@ NullableString(const std::string &s) noexcept
 	return s.empty() ? nullptr : s.c_str();
 }
 
+
 struct Config {
+	using IgnoreListMap = std::map<std::string, IgnoreList>;
+
 	/** don't daemonize the mpdscribble process */
 	bool no_daemon = false;
 
@@ -41,6 +45,8 @@ struct Config {
 	int verbose = -1;
 	enum file_location loc = file_unknown;
 
+	// Key=file path, value=loaded ignore list
+	IgnoreListMap ignore_lists;
 	std::forward_list<ScrobblerConfig> scrobblers;
 };
 

--- a/src/IgnoreList.cxx
+++ b/src/IgnoreList.cxx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The Music Player Daemon Project
+
+#include "IgnoreList.hxx"
+
+#include <cassert>
+#include <algorithm>
+
+[[gnu::pure]]
+static constexpr bool
+MatchIgnoreIfSpecified(std::string_view ignore, std::string_view value)
+{
+	return ignore.empty() || ignore == value;
+}
+
+bool
+IgnoreListEntry::matches_record(const Record& record) const noexcept
+{
+	/*
+	   The below logic would always return true if the entry is empty.
+	   This condition should never be true, as we don't push empty entries.
+	*/
+	assert(!artist.empty() || !album.empty() || !title.empty());
+
+	/*
+	   Note the mismatch of 'title' and 'track' field names with the Record structure.
+	   This is not a bug - the Record structure does not use the expected field names.
+	*/
+	return MatchIgnoreIfSpecified(artist, record.artist) &&
+	       MatchIgnoreIfSpecified(album, record.album) &&
+	       MatchIgnoreIfSpecified(title, record.track) &&
+	       MatchIgnoreIfSpecified(track, record.number);
+}
+
+bool
+IgnoreList::matches_record(const Record& record) const noexcept
+{
+	return std::any_of(entries.begin(),
+	                   entries.end(),
+	                   [&record](const auto& entry) { return entry.matches_record(record); });
+}

--- a/src/IgnoreList.hxx
+++ b/src/IgnoreList.hxx
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The Music Player Daemon Project
+
+#ifndef IGNORE_LIST_HXX
+#define IGNORE_LIST_HXX
+
+#include <string>
+#include <vector>
+
+#include "Record.hxx"
+
+struct IgnoreListEntry {
+
+	std::string artist;
+	std::string album;
+	std::string title;
+	std::string track;
+
+	[[nodiscard]] bool matches_record(const Record& record) const noexcept;
+};
+
+struct IgnoreList {
+	std::vector<IgnoreListEntry> entries;
+
+	[[nodiscard]] bool matches_record(const Record& record) const noexcept;
+};
+
+
+#endif

--- a/src/Scrobbler.cxx
+++ b/src/Scrobbler.cxx
@@ -436,6 +436,10 @@ Scrobbler::ScheduleNowPlaying(const Record &song) noexcept
 		/* there's no "now playing" support for files */
 		return;
 
+	if (config.ignore_list && config.ignore_list->matches_record(song)) {
+		return;
+	}
+
 	now_playing = song;
 
 	if (state == State::READY && !submit_timer.IsPending())
@@ -515,6 +519,10 @@ Scrobbler::Submit() noexcept
 void
 Scrobbler::Push(const Record &song) noexcept
 {
+	if (config.ignore_list && config.ignore_list->matches_record(song)) {
+		return;
+	}
+
 	if (file != nullptr) {
 		fprintf(file, "%s %s - %s\n",
 			log_date(),

--- a/src/ScrobblerConfig.hxx
+++ b/src/ScrobblerConfig.hxx
@@ -4,6 +4,8 @@
 #ifndef SCROBBLER_CONFIG_HXX
 #define SCROBBLER_CONFIG_HXX
 
+#include "IgnoreList.hxx"
+
 #include <string>
 
 struct ScrobblerConfig {
@@ -29,6 +31,8 @@ struct ScrobblerConfig {
 	 * AudioScrobbler server.
 	 */
 	std::string file;
+
+	IgnoreList* ignore_list;
 };
 
 #endif


### PR DESCRIPTION
Hi!

Thank you for all your work with mpd/mpdscribble. It's a seriously great project!

I'm hoping to contribute with this little feature I built for my own use.
It simply allows you to specify an ignore list per scrobbler in which you can specify tracks for the scrobbler to ignore.

I decided to make it per scrobbler, as for my personal use case, I have a file scrobbler that does not have excludes while last.fm has some excludes.

The PR includes a manpage update describing the file format in detail.
I'm adding the rendered excerpt here for your convenience.

```
IGNORE FILE FORMAT
       Tracks can be ignored by listing them in an ignore file.  Each line  in
       the  file  specifies a pattern to match tracks you wish to exclude from
       scrobbling.  The format is simple and flexible, allowing you  to  match
       by artist, album, title, track number or a combination of these fields.

   File Format
       A  tag match is specified as tagname="value", where tagname is replaced
       with one of the supported tags (artist, album, title,  track).   Values
       must be quoted and spaces are not allowed surrounding the equal sign.

       Each line consists of one or more tag matches separated by spaces:
           tag1="value1" tag2="value2" ...

       Tags can appear in any order and blank lines are ignored.

       A  backslash  (\) is interpreted as escape character and may be used to
       escape literal double quotes within a value.  To write a literal  back-
       slash, use a double backslash (\\).

       Each  line  is limited to 4096 characters including the newline charac-
       ter.  Superflous characters are silently ignored.


   Examples
       If a tag is omitted, any value for that field is matched:

       title="Bohemian Rhapsody"
              Matches any track titled Bohemian Rhapsody.

       artist="Queen"
              Matches any track by Queen, regardless of album or title.

       artist="Queen" album="A Night at the Opera"
              Matches any track by Queen from A Night at the Opera, regardless
              of title.

       artist="Queen" album="A Night at the Opera" title="Bohemian Rhapsody"
              Matches a specific track by Queen, from A Night  at  the  Opera,
              titled Bohemian Rhapsody.

       artist="Queen" album="A Night at the Opera" track="01"
              Matches  the  first  track  on the album A Night at the Opera by
              Queen.  Note that track tags are interpreted  as  text  and  not
              numbers, meaning "01" is not the same as "1".

       artist="Clark \"Plazmataz\" Powell"
              Matches tracks by Clark "Plazmataz" Powell.

```

Kind regards,
Fabian

EDIT: updated rendered man page excerpt to reflect new file format